### PR TITLE
Dependency hell resolver.

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "dependencies": {
         "@greymass/eosio": "^0.4.7",
         "@jafri/asmcrypto.js": "^2.3.2",
-        "@proton/signing-request": "^2.2.2-9",
+        "@proton/signing-request": "2.2.2-9",
         "bson": "^4.6.0",
         "fetch-ponyfill": "^7.1.0",
         "isomorphic-ws": "^4.0.1",


### PR DESCRIPTION
We can never get the specified version or version up than 2.x through node package manager with such semantics. Please rebuild the web-sdk.

http://dl4.joxi.net/drive/2021/12/26/0052/0082/3424338/38/72f2900f08.jpg
https://docs.npmjs.com/about-semantic-versioning




